### PR TITLE
Add theme_color variable support for Chrome on Android

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,3 +55,6 @@ copyright:
 
 # Google Analytics (add the UA Code, e.g.: UA-xxxxxxxx-1)
 google_analytics:
+
+# Default Theme Color for Chrome on Android Lollipop (Use RGB ColorCode without `#`, e.g.: `db5945`)
+theme_color: 7E9576

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,4 +38,6 @@
 		ga('send', 'pageview');
 	</script>
 	{% endif %}
+	<!-- Theme Color for Chrome on Android Lollipop -->
+	<meta name="theme-color" content="#{% if page.theme_color %}{{ page.theme_color }}{% else %}{{ site.theme_color }}{% endif %}">
 </head>

--- a/_posts/2014-02-27-hello-cosette.md
+++ b/_posts/2014-02-27-hello-cosette.md
@@ -5,6 +5,7 @@ quote: "Thinny reaches a new version, with mobile support and some other cool fe
 image: /media/2014-02-27-hello-cosette/cover.jpg
 video: false
 comments: true
+theme_color: 302F2D
 ---
 
 #Thinny 2.1, codename "[Cosette](http://lesmiserables.wikia.com/wiki/Cosette)"


### PR DESCRIPTION
Chrome on Android includes a variable to theme the address bar with your primary color. [^1]

Here I have added support for it to Thinny by:

- Adding the necessary code to the `head.html` file
- Adding a site-wide variable to `_config.yml` called `theme_color` and a small description on use
- Added a per-post variable that will override the site wide one.
- Added some default values pulled from the site-wide cover image and Cosette demo post

This would be awesome if it could be added!

[^1]: http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android