### PR TITLE
Allow Custom Post Excerpts based on Quote

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: Home
 		<div>
 			<span class="post-date">{{ post.date | date_to_long_string }}</span>
 			<h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
-			<p class="post-description">{{ post.content | strip_html | truncatewords: 50 }}</p>
+			<p class="post-description">{% if post.quote %}{{ post.quote }}{% else %}{{ post.content | strip_html | truncatewords: 50 }}{% endif %}</p>
 		</div>
 		<br>
 	{% endfor %}


### PR DESCRIPTION
Sometimes, the default post excerpt/description isn't the best.

For example, I have a variable for a weekly post I do and that variable shows up in the excerpt:
```markdown
WELCOME TO HOME SCREEN SUNDAY! Welcome to Home Screen Sunday, a series every Sunday where we look at home screens from me or even others and explain how it works. It can be Android, iOS, or even Desktop! LET'S DO IT! First up, we have my current Android 5.0 Lollipop...
```

When it actually looks like this:
```markdown
{{ site.data.hss.intro }}

First up, we have my current Android 5.0 Lollipop Home Screen on my Moto G.
```

The variable shouldn't show up as it is not unique to the post. Every one of my posts for that series start like that and that makes the description not very useful.

Instead, we can use an if else statement to say if the post has a quote, then make that the description instead.

So if this was my quote, it would be this instead:
```markdown
This HSS we have my current Android 5.0 Lollipop Home Screen on my Moto G.
```