### PR TITLE
Fix glitchyness with parallax scrolling

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -27,6 +27,7 @@ header, footer {
 header a, footer a {
 	transition-duration: .25s;
 	text-decoration: none;
+	transition-property: width, height, background-size, margin, opacity;
 }
 
 footer {


### PR DESCRIPTION
Right now the logo jumps around a little when you scroll. To fix this I made `transform` unaffected by `transition`.