### PR TITLE
Fix 404 image not displaying

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,8 @@
 ---
 layout: fullscreen
 title: "404"
-image: /assets/images/luke.png
+image:
+    url: /assets/images/luke.png
 ---
 
 <div id="post-info">


### PR DESCRIPTION
The default background image for the 404 page wasn't working. Fixed the Front Matter