### PR TITLE
Fix about page link/location

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About the site, the author, the life, the universe and everything more.
+permalink: about/
 ---
 
 <div class="message">


### PR DESCRIPTION
The default `_config.yml` provides a link to `about/`, but `about.md` is being placed at `about.html` when the pages are generated, resulting in a broken default link. This change places it at `about/index.html` so that the clean, default `about/` link works.