### PR TITLE
Specify canonical url for Disqus comments

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -2,6 +2,7 @@
 	<div id="disqus_thread"></div>
 	<script type="text/javascript">
 		var disqus_shortname = '{{ site.disqus }}';
+		var disqus_url = '{{ site.url }}{{ page.url }}';
 
 		(function() {
 			var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
Due to inconsistency of URLs (http/https, query string, hash), Disqus comments can be separated in one post. Specifying a canonical URL instead of using `window.location.href` avoids this. https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables#disqus_url