### PR TITLE
Add wdm to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages', '>=28'
 gem 'html-proofer', '>=1.4.0'
+gem 'wdm', '~> 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
This is needed when running jekyll on a Windows machine to test updates to the site. See http://jekyll-windows.juthilo.com/4-wdm-gem/