### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Thinny - The Infinite's Nymphet
+# Thinny - The Infinite's Nymphet
 
 
 ----
 
-###Attention
+### Attention
 
 I'm no longer maintaining this repository.
 
@@ -11,25 +11,25 @@ If you want to add something, feel free to send a pull request, which I'll see i
 
 ----
 
-##Installation
+## Installation
 1. Clone the repo: `git clone https://github.com/camporez/Thinny.git Thinny`
 2. Open the folder: `cd Thinny`
 3. Install the dependencies: `bundle install`
 4. Build the website: `bundle exec jekyll serve`
 
-##About
+## About
 Thinny is a beautiful theme for [Jekyll](http://jekyllrb.com/).
 
 (if you're looking for the [Ghost](http://ghost.org) release of the theme, check [this page](https://github.com/camporez/Thinny/releases/tag/v0.3-alexandra))
 
-##Demo
+## Demo
 [![Preview image](https://f.cloud.github.com/assets/5755892/2002329/bdb5a052-85ed-11e3-8e00-a892910b6917.png)](http://camporez.github.io/)
 The above image is a preview of how the post header looks on Thinny.
 
 A live demo is available [on my personal blog](http://camporez.github.io/).
 
-##More information
+## More information
 Read the blog post [here](http://camporez.github.io/blog/thinny-2/).
 
-##Reporting issues
+## Reporting issues
 You can report an issue or request a feature [here](http://github.com/camporez/Thinny/issues) or on [twitter](http://twitter.com/iancamporez).

--- a/_posts/2014-01-22-thinny-2.md
+++ b/_posts/2014-01-22-thinny-2.md
@@ -10,11 +10,11 @@ comments: true
 Three months ago, I released an (unfinished) theme for Ghost 0.3: [Thinny 0.3](http://github.com/camporez/Thinny), codename "[Alexandra](http://nikita2010.wikia.com/wiki/Alexandra_Udinov)".
 But now I'm migrating my blog to Jekyll, and also migrating the theme. With a brand new look, Thinny 2 also brings a lot of new features and polishment. Actually, it was completely remaked.
 
-#Thinny 2.0, codename "[Bianca](http://memoriaglobo.globo.com/programas/entretenimento/novelas/caras-bocas/caras-bocas-bianca-isabelle-drummond.htm)"
+# Thinny 2.0, codename "[Bianca](http://memoriaglobo.globo.com/programas/entretenimento/novelas/caras-bocas/caras-bocas-bianca-isabelle-drummond.htm)"
 
 This new version of Thinny goes deeper with the [initial idea](http://ghost-camporez.rhcloud.com/making-applications-icon-smaller-on-gnome-shells-top-panel/) of a big image before the post. As the saying goes, <cite>a picture is worth a thousand words</cite>, so we expanded the concept. I mean, literally. The post image (or video!) is now full width and full height, and can be easily add with the use of a variable.
 
-##Features
+## Features
 
 ### Lists and text formatting
 
@@ -28,7 +28,7 @@ You can use various HTML tags:
 2. <del>Deleted</del> text should use `<del>` and <ins>inserted</ins> text should use `<ins>`.
 3. Superscript <sup>text</sup> uses `<sup>` and subscript <sub>text</sub> uses `<sub>`.
 
-###Messages, code and images
+### Messages, code and images
 
 <div class="message">This is a <strong>warning</strong> message. Now, you can keep falling in love with this theme...</div>
 

--- a/_posts/2014-02-27-hello-cosette.md
+++ b/_posts/2014-02-27-hello-cosette.md
@@ -9,7 +9,7 @@ comments: true
 theme_color: 302F2D
 ---
 
-#Thinny 2.1, codename "[Cosette](http://lesmiserables.wikia.com/wiki/Cosette)"
+# Thinny 2.1, codename "[Cosette](http://lesmiserables.wikia.com/wiki/Cosette)"
 
 Cosette is the main character of the french novel _Les Misérables_, published in 1862 by _Victor Hugo_.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
